### PR TITLE
Recognize `?php=` parameter only

### DIFF
--- a/src/CommentParser/index.ts
+++ b/src/CommentParser/index.ts
@@ -2,7 +2,7 @@ export class CommentParser {
   parseComment(comment: string): LinkEntry[] {
     let matches;
     let snippets = [];
-    const regexp = /psalm\.dev\/r\/(\w+)(\?([^\s]+))?/g;
+    const regexp = /psalm\.dev\/r\/(\w+)(\?(php=\d+\.\d+))?/g;
 
     const seen: Set<string> = new Set;
 

--- a/test/CommentParser.test.ts
+++ b/test/CommentParser.test.ts
@@ -66,4 +66,33 @@ describe('CommentParser', () => {
       parser.parseComment('One link: https://psalm.dev/r/0f9f06ebd6')[0].params
     ).toEqual('')
   })
+
+  test('does not include closing paren in params', () => {
+    expect(
+      parser.parseComment('(psalm.dev/r/265ca1743a?php=7.4)')
+    ).toEqual([
+      {
+        link: 'https://psalm.dev/r/265ca1743a?php=7.4',
+        snippet: '265ca1743a',
+        params: 'php=7.4'
+      }
+    ])
+  })
+
+  test('does not include trailing comma or period in params', () => {
+    expect(
+      parser.parseComment('psalm.dev/r/265ca1743a?php=7.4, psalm.dev/r/265ca1743b?php=7.4.')
+    ).toEqual([
+      {
+        link: 'https://psalm.dev/r/265ca1743a?php=7.4',
+        snippet: '265ca1743a',
+        params: 'php=7.4'
+      },
+      {
+        link: 'https://psalm.dev/r/265ca1743b?php=7.4',
+        snippet: '265ca1743b',
+        params: 'php=7.4'
+      }
+    ])
+  })
 })


### PR DESCRIPTION
This allows to parse it strictly and automatically exclude trailing
characters like comma, period or closing paren

Fixes psalm/psalm-github-bot#544